### PR TITLE
Convert Application.mk into unix EOL

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -10,7 +10,7 @@ SOURCES_C := \
 	$(SOURCE_DIR)/audio.c \
 	$(SOURCE_DIR)/video.c \
 	$(SOURCE_DIR)/ports.c \
-	$(SOURCE_DIR)/osd.c \
+	$(SOURCE_DIR)/osd.c
 
 ifeq ($(STATIC_LINKING),1)
 else

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,2 +1,1 @@
-APP_STL := c++_static
 APP_ABI := all


### PR DESCRIPTION
It had windown EOL that has confused buildbot

While on it, remove STL since we don't have any C++

While on it remove extra backslash in Makefile.common