### PR TITLE
iOS: more updates to min version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,13 +89,13 @@ else ifneq (,$(findstring ios,$(platform)))
 	ifeq ($(platform),ios9)
 		CC = cc -arch armv7 -isysroot $(IOSSDK)
 		LD = cc -arch armv7 -isysroot $(IOSSDK)
-		CC	+= -miphoneos-version-min=8.0
-		CXXFLAGS += -miphoneos-version-min=8.0
+		CC	+= -miphoneos-version-min=5.0
+		CXXFLAGS += -miphoneos-version-min=5.0
 	else
 		CC = cc -arch arm64 -isysroot $(IOSSDK)
 		LD = cc -arch arm64 -isysroot $(IOSSDK)
-		CC	+= -miphoneos-version-min=8.0
-		CXXFLAGS += -miphoneos-version-min=8.0
+		CC	+= -miphoneos-version-min=7.0
+		CXXFLAGS += -miphoneos-version-min=7.0
 	endif
 
 # PS3


### PR DESCRIPTION
As an update to https://github.com/libretro/FreeChaF/pull/39.

https://git.libretro.com/libretro/FreeChaF/-/pipelines/272199

As the previous PR mentioned, the first build of iOS that supported arm64 was iOS 7, so for the arm64 build this moves the min ver back to 7. This also moves the min ver for the ios9 (armv7) build back to iOS 5, where it was before #39.